### PR TITLE
RightCheckBox overflow, powersave anchor, gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ moc_*
 Makefile
 documentation.list
 glacier-settings
+CMakeLists.txt.user*
+CMakeCache.txt*
+CMakeFiles*

--- a/src/qml/components/RightCheckBox.qml
+++ b/src/qml/components/RightCheckBox.qml
@@ -41,6 +41,7 @@ Item {
         width: parent.width
         anchors {
             left: rightCheckBox.left
+            right: rightCheckBoxCheckBox.left
             verticalCenter: parent.verticalCenter
         }
         wrapMode: Text.Wrap

--- a/src/qml/plugins/powersave/powersave.qml
+++ b/src/qml/plugins/powersave/powersave.qml
@@ -76,10 +76,6 @@ Page {
             id: forcePowerSaveCheckBox
             label: qsTr("Force power save")
             checked: displaySettings.powerSaveModeForced
-            anchors{
-                right: parent.right
-                verticalCenter: nameLabel.verticalCenter
-            }
             onClicked:{
                 displaySettings.powerSaveModeForced = forcePowerSaveCheckBox.checked
                 if(forcePowerSaveCheckBox.checked) {


### PR DESCRIPTION
RightCheckBox add anchor of text to avoid overlap. 

Remove anchors in powersave, because changed to RightCheckbox (forgotten during refactoring)

add some files into gitignore